### PR TITLE
CI success

### DIFF
--- a/metnet/models/metnet.py
+++ b/metnet/models/metnet.py
@@ -41,7 +41,7 @@ class MetNet(torch.nn.Module, PyTorchModelHubMixin):
         num_att_layers = self.config["num_att_layers"]
         output_channels = self.config["output_channels"]
         use_preprocessor = self.config["use_preprocessor"]
-        num_att_heads = self.config["num_att_heads"]
+        num_att_heads = self.config.get("num_att_heads", 16)
 
         self.forecast_steps = forecast_steps
         self.input_channels = input_channels

--- a/metnet/models/metnet_pv.py
+++ b/metnet/models/metnet_pv.py
@@ -116,7 +116,6 @@ class MetNetPV(torch.nn.Module, PyTorchModelHubMixin):
             + pv_id_embedding_channels * num_pv_systems
         )
 
-        
         # FC layer, takes in 'econcded_timesteps', pv history, and embedding of pv ids
         # self.fc1 = nn.Linear(in_features=606976, out_features=fc_1_channels)
 
@@ -124,7 +123,11 @@ class MetNetPV(torch.nn.Module, PyTorchModelHubMixin):
         num_features_after_pooling = (input_size // 4 // avg_pool_size) ** 2 * hidden_dim
 
         # Calculating the total number of features for the linear layer input
-        total_features = num_features_after_pooling + (n_pv_timestamps * pv_fc_out_channels) + (pv_id_embedding_channels * num_pv_systems)
+        total_features = (
+            num_features_after_pooling
+            + (n_pv_timestamps * pv_fc_out_channels)
+            + (pv_id_embedding_channels * num_pv_systems)
+        )
 
         # Updating the in_features parameter of nn.Linear
         self.fc1 = nn.Linear(in_features=total_features, out_features=fc_1_channels)


### PR DESCRIPTION
# Pull Request

## Description

Fixes #


There were 2 issues  : 

1. RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x265728 and 606976x256) and 

2 .KeyError: 'num_att_heads'  I have made some changes in metnet_pv and metnet.py.  By doing that workflows pass all the tests, but I tried to run the workflow on a forked repo but didn't work. I have tried it locally and it works. 
 Please check if it's correct.

![image](https://github.com/openclimatefix/metnet/assets/98907006/3521978e-a677-4ee0-9e41-2ef71151845f)



_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] No

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x]I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
