### PR TITLE
fix: correct spelling in README and MBConv layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ from datasets import load_dataset
 dataset = load_dataset("openclimatefix/goes-mrms")
 ```
 
-This uses the publicly avaiilable GOES-16 data and the MRMS archive to create a similar set of data to train and test on, with various other splits available as well.
+This uses the publicly available GOES-16 data and the MRMS archive to create a similar set of data to train and test on, with various other splits available as well.
 
 ## Pretrained Weights
 Pretrained model weights for MetNet and MetNet-2 have not been publicly released, and there is some difficulty in reproducing their training. We release weights for both MetNet and MetNet-2 trained on cloud mask and satellite imagery data with the same parameters as detailed in the papers on HuggingFace Hub for [MetNet](https://huggingface.co/openclimatefix/metnet) and [MetNet-2](https://huggingface.co/openclimatefix/metnet-2). These weights can be downloaded and used using:

--- a/metnet/layers/MBConv.py
+++ b/metnet/layers/MBConv.py
@@ -67,7 +67,7 @@ class MBConv(nn.Module):
             # TODO: Check if downscaling is needed at all. May impact layer normalisation.
             raise NotImplementedError(
                 "Downscaling in MBConv hasn't been implemented as it \
-                isnt used in Metnet3"
+                isn't used in Metnet3"
             )
 
         self.main_branch = nn.Sequential(


### PR DESCRIPTION
## Summary
This PR fixes two spelling errors found in the codebase:

1. **README.md** (line 36): Corrected "avaiilable" to "available" in the description of GOES-16 data
2. **metnet/layers/MBConv.py** (line 70): Corrected "isnt" to "isn't" in the NotImplementedError message

## Changes
- Fixed typo in README.md
- Fixed typo in MBConv.py error message

## Impact
These are simple text-only changes that improve code readability and maintain professional documentation standards. No functional changes to the code.