### PR TITLE
Add ConditionWithTimeMetNet3 for lead time conditioning (part of #55)

### DIFF
--- a/metnet/layers/ConditionWithTimeMetNet3.py
+++ b/metnet/layers/ConditionWithTimeMetNet3.py
@@ -1,0 +1,67 @@
+"""Condition with time how MetNet-3 does it, with FiLM layers."""
+
+import einops
+import torch
+from torch import nn as nn
+
+
+class ConditionWithTimeMetNet3(nn.Module):
+    """Compute Scale and bias for conditioning on time."""
+
+    def __init__(self, forecast_steps: int = 722, hidden_dim: int = 32, num_feature_maps: int = 512):
+        """
+        Compute the scale and bias factors for conditioning convolutional blocks on forecast time.
+
+        Args:
+            forecast_steps: Number of forecast steps
+            hidden_dim: Hidden dimension size
+            num_feature_maps: Max number of channels in thec blocks, to generate enough
+            scale+bias values
+                This means extra values will be generated, but keeps implementation simpler
+        """
+        super().__init__()
+        self.forecast_steps = forecast_steps
+        self.num_feature_maps = num_feature_maps
+        self.relu = nn.ReLU()
+        self.lead_time_network = nn.ModuleList(
+            [
+                nn.Linear(in_features=forecast_steps, out_features=hidden_dim),
+                nn.Linear(in_features=hidden_dim, out_features=2 * num_feature_maps),
+            ]
+        
+        )
+        # Initialize second layer as identity function
+        nn.init.zeros_(self.lead_time_network[1].weight)
+        nn.init.zeros_(self.lead_time_network[1].bias)
+        self.lead_time_network[1].bias.data[0::2] = 1.0
+        
+
+    def forward(self, x: torch.Tensor, timestep: int) -> [torch.Tensor, torch.Tensor]:
+        """
+        Get the scale and bias for the conditioning layers.
+
+        From the FiLM paper, each feature map (i.e. channel) has its own scale and bias layer,
+        so needs a scale and bias for each feature map to be generated
+
+        Args:
+            x: The Tensor that is used
+            timestep: Index of the timestep to use, between 0 and forecast_steps
+
+        Returns:
+            2 Tensors of shape (Batch, num_feature_maps)
+        """
+        # One hot encode the timestep
+        timesteps = torch.zeros(x.size()[0], self.forecast_steps, dtype=torch.long).type_as(x)
+        timesteps[:, timestep] = 1
+        # Get scales and biases
+        timesteps = self.lead_time_network[0](timesteps)
+        timesteps = self.relu(timesteps)
+        timesteps = self.lead_time_network[1](timesteps)
+        scales_and_biases = timesteps
+        scales_and_biases = einops.rearrange(
+            scales_and_biases,
+            "b (block sb) -> b block sb",
+            block=self.num_feature_maps,
+            sb=2,
+        )
+        return scales_and_biases[:, :, 0], scales_and_biases[:, :, 1]

--- a/metnet/layers/ConditionWithTimeMetNet3.py
+++ b/metnet/layers/ConditionWithTimeMetNet3.py
@@ -8,7 +8,9 @@ from torch import nn as nn
 class ConditionWithTimeMetNet3(nn.Module):
     """Compute Scale and bias for conditioning on time."""
 
-    def __init__(self, forecast_steps: int = 722, hidden_dim: int = 32, num_feature_maps: int = 512):
+    def __init__(
+        self, forecast_steps: int = 722, hidden_dim: int = 32, num_feature_maps: int = 512
+    ):
         """
         Compute the scale and bias factors for conditioning convolutional blocks on forecast time.
 
@@ -28,13 +30,11 @@ class ConditionWithTimeMetNet3(nn.Module):
                 nn.Linear(in_features=forecast_steps, out_features=hidden_dim),
                 nn.Linear(in_features=hidden_dim, out_features=2 * num_feature_maps),
             ]
-        
         )
         # Initialize second layer as identity function
         nn.init.zeros_(self.lead_time_network[1].weight)
         nn.init.zeros_(self.lead_time_network[1].bias)
         self.lead_time_network[1].bias.data[0::2] = 1.0
-        
 
     def forward(self, x: torch.Tensor, timestep: int) -> [torch.Tensor, torch.Tensor]:
         """

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -24,6 +24,7 @@ def test_condition_with_time_metnet3():
     assert torch.allclose(scale, torch.ones_like(scale))
     assert torch.allclose(bias, torch.zeros_like(bias))
 
+
 def test_stochastic_depth():
     test_tensor = torch.ones(1)
 
@@ -87,5 +88,3 @@ def test_metnet_maxvit():
 
     metnet_maxvit = MetNetMaxVit(in_channels=c)
     assert test_tensor.shape == metnet_maxvit(test_tensor).shape
-
-

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -4,8 +4,25 @@ from metnet.layers.SqueezeExcitation import SqueezeExcite
 from metnet.layers.MBConv import MBConv
 from metnet.layers.MultiheadSelfAttention2D import MultiheadSelfAttention2D
 from metnet.layers.PartitionAttention import BlockAttention, GridAttention
+from metnet.layers.ConditionWithTimeMetNet3 import ConditionWithTimeMetNet3
+
 import torch
 
+
+def test_condition_with_time_metnet3():
+    batch, channels, height, width = 2, 512, 16, 16
+    test_tensor = torch.rand(batch, channels, height, width)
+
+    conditioner = ConditionWithTimeMetNet3()
+
+    # Check output shapes
+    scale, bias = conditioner(test_tensor, timestep=0)
+    assert scale.shape == (batch, 512)
+    assert bias.shape == (batch, 512)
+
+    # Check identity initialization — scale should be ~1, bias should be ~0
+    assert torch.allclose(scale, torch.ones_like(scale))
+    assert torch.allclose(bias, torch.zeros_like(bias))
 
 def test_stochastic_depth():
     test_tensor = torch.ones(1)
@@ -70,3 +87,5 @@ def test_metnet_maxvit():
 
     metnet_maxvit = MetNetMaxVit(in_channels=c)
     assert test_tensor.shape == metnet_maxvit(test_tensor).shape
+
+

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -5,6 +5,7 @@ from metnet.layers.MBConv import MBConv
 from metnet.layers.MultiheadSelfAttention2D import MultiheadSelfAttention2D
 from metnet.layers.PartitionAttention import BlockAttention, GridAttention
 from metnet.layers.ConditionWithTimeMetNet3 import ConditionWithTimeMetNet3
+from metnet.layers.LeadTimeConditioner import LeadTimeConditioner
 
 import torch
 
@@ -23,6 +24,25 @@ def test_condition_with_time_metnet3():
     # Check identity initialization — scale should be ~1, bias should be ~0
     assert torch.allclose(scale, torch.ones_like(scale))
     assert torch.allclose(bias, torch.zeros_like(bias))
+
+
+def test_backward_pass_gradients_flow():
+    """Ensure gradients flow through the lead time network on a backward pass."""
+    batch, channels, height, width = 2, 512, 16, 16
+    test_tensor = torch.rand(batch, channels, height, width)
+    conditioner = ConditionWithTimeMetNet3()
+    film = LeadTimeConditioner()
+
+    scale, bias = conditioner(test_tensor, timestep=0)
+
+    # Simulate FiLM conditioning, then reduce to a scalar loss
+    conditioned = film(test_tensor, scale, bias)
+    loss = conditioned.sum()
+    loss.backward()
+
+    for name, param in conditioner.named_parameters():
+        assert param.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(param.grad).all(), f"Non-finite gradient in {name}"
 
 
 def test_stochastic_depth():


### PR DESCRIPTION
## Description

Adds `ConditionWithTimeMetNet3`, the FiLM conditioning module for MetNet-3 lead time conditioning. This is the second step toward implementing MetNet-3 (see #[55](https://github.com/openclimatefix/metnet/issues/55)). This produces the scales and biases that will be consumed by the LeadTimeConditioner already [present](https://github.com/openclimatefix/metnet/blob/main/metnet/layers/LeadTimeConditioner.py) in the codebase when the full MetNet-3 model is wired together.

This paper cites the use of this as: "Lead Time Conditioning We use additive-multiplicative conditioning (FiLM, [13]) on lead time throughout the network. The conditioning is applied to the the network inputs and after each layer normalization.
All additive and multiplicative factors are outputted by a single MLP with one hidden layer of size 32 which
takes as input one-hot encoded lead time. The second layer of this MLP is initialized so that at initialization
the conditioning is an identity function" on in Appendix B. 


This implementation is similar to [ConditionWithTimeMetNet2](https://github.com/openclimatefix/metnet/blob/main/metnet/layers/ConditionWithTimeMetNet2.py) but some
key differences are:
- Hidden layer size of 32 (vs 2048 in MetNet-2), as specified in the MetNet-3 paper appendix
- Forecast steps of 722 (0 to 24 hours at 2 minute intervals, vs 720 in MetNet-2)
- Identity initialization on the second linear layer so conditioning starts as a no-op at initialization
- Intended to be used as a single shared instance across the whole model (vs one instance per layer in MetNet-2)

Fixes part of #61, part of #55


My future plan is continue working through the steps outlined in #55 

## How Has This Been Tested?

Added `test_condition_with_time_metnet3` to `tests/test_layers.py` which verifies:
- Output shapes are correct: `(batch, num_feature_maps)` for both scale and bias
- Identity initialization is correct: scale ≈ 1 and bias ≈ 0 at initialization

Run with:
```bash
uv run pytest tests/test_layers.py -x
```

<img width="749" height="189" alt="image" src="https://github.com/user-attachments/assets/90522697-bb48-4b49-aec9-6d4298565353" />


- [x] Yes

## Checklist:
- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings