### PR TITLE
Implement MetNet3 Embeddings

### DIFF
--- a/metnet/layers/InputEmbedding.py
+++ b/metnet/layers/InputEmbedding.py
@@ -18,7 +18,7 @@ class InputEmbedding(nn.Module):
 
     def __init__(self, in_channels: int, out_channels: int = 512):
         """Initialize InputEmbedding.
-        
+
         Args:
             in_channels: Number of input channels after concatenating all inputs
                 (e.g. 793 for the 4km high-resolution path, 17 for the 8km

--- a/metnet/layers/InputEmbedding.py
+++ b/metnet/layers/InputEmbedding.py
@@ -1,0 +1,38 @@
+"""Input embedding layer for MetNet-3, projecting concatenated inputs to the
+internal channel representation."""
+
+import torch
+from torch import nn as nn
+
+class InputEmbedding(nn.Module):
+    """
+    Project concatenated input channels to the network's internal representation size.
+
+    From the MetNet-3 paper, Section "Inputs":
+    'Inputs are embedded to the internal representation of size 512 using a linear layer.'
+
+    Since inputs are spatial grids rather than flat vectors, this linear layer is
+    implemented as a 1x1 convolution, which applies the same linear projection
+    independently at every spatial location.
+    """
+
+    def __init__(self, in_channels: int, out_channels: int = 512):
+        """
+        Args:
+            in_channels: Number of input channels after concatenating all inputs
+                (e.g. 793 for the 4km high-resolution path, 17 for the 8km
+                low-resolution path)
+            out_channels: Internal representation size, 512 as per the MetNet-3 paper
+        """
+        super().__init__()
+        self.embed = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x: Concatenated input tensor of shape [Batch, in_channels, Height, Width]
+
+        Returns:
+            Tensor of shape [Batch, out_channels, Height, Width]
+        """
+        return self.embed(x)

--- a/metnet/layers/InputEmbedding.py
+++ b/metnet/layers/InputEmbedding.py
@@ -4,6 +4,7 @@ internal channel representation."""
 import torch
 from torch import nn as nn
 
+
 class InputEmbedding(nn.Module):
     """
     Project concatenated input channels to the network's internal representation size.

--- a/metnet/layers/InputEmbedding.py
+++ b/metnet/layers/InputEmbedding.py
@@ -1,5 +1,4 @@
-"""Input embedding layer for MetNet-3, projecting concatenated inputs to the
-internal channel representation."""
+"""Input embedding layer for MetNet-3"""
 
 import torch
 from torch import nn as nn
@@ -18,7 +17,8 @@ class InputEmbedding(nn.Module):
     """
 
     def __init__(self, in_channels: int, out_channels: int = 512):
-        """
+        """Initialize InputEmbedding.
+        
         Args:
             in_channels: Number of input channels after concatenating all inputs
                 (e.g. 793 for the 4km high-resolution path, 17 for the 8km
@@ -29,7 +29,8 @@ class InputEmbedding(nn.Module):
         self.embed = nn.Conv2d(in_channels, out_channels, kernel_size=1)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        """
+        """Compute input embeddings
+
         Args:
             x: Concatenated input tensor of shape [Batch, in_channels, Height, Width]
 

--- a/metnet/layers/TopographicalEmbedding.py
+++ b/metnet/layers/TopographicalEmbedding.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 
 class TopographicalEmbedding(nn.Module):
-    """ Topographical Embedding class.
+    """Topographical Embedding class.
 
     From MetNet-3 paper: 'we allocate a grid of embeddings with a stride of 4 km
     where each point is associated with 20 scalar parameters.'
@@ -19,7 +19,7 @@ class TopographicalEmbedding(nn.Module):
         embedding_dim: int = 20,
     ):
         """Initialize TopographicalEmbedding.
-    
+
         Args:
             grid_height: Number of 4km grid points in y direction
             grid_width: Number of 4km grid points in x direction
@@ -31,7 +31,7 @@ class TopographicalEmbedding(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Compute topographical embeddings for the input tensor.
-    
+
         Args:
             x: Input tensor [Batch, Channels, Height, Width]
 

--- a/metnet/layers/TopographicalEmbedding.py
+++ b/metnet/layers/TopographicalEmbedding.py
@@ -1,0 +1,43 @@
+"""Topographical Embedding for MetNet3."""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class TopographicalEmbedding(nn.Module):
+    """
+    Topographical Embedding class
+
+    "we allocate a grid of embeddings with a stride of 4 km where each point is associated with 20 scalar parameters." 
+
+    """
+    def __init__(
+        self,
+        grid_height: int,  # number of 4km grid points in y direction
+        grid_width: int,   # number of 4km grid points in x direction
+        embedding_dim: int = 20,
+    ):
+        super().__init__()
+        # Learnable parameter grid — trained like NLP embeddings
+        self.embedding_grid = nn.Parameter(
+            torch.randn(1, embedding_dim, grid_height, grid_width)
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x is [B, C, H, W] — we just need batch size and spatial dims
+        B, _, H, W = x.shape
+        
+        # Expand grid to batch size
+        grid = self.embedding_grid.expand(B, -1, -1, -1)
+        
+        # Bilinear interpolation to input spatial size
+        # This handles the case where input spatial size differs from grid size
+        embeddings = F.interpolate(
+            grid,
+            size=(H, W),
+            mode="bilinear",
+            align_corners=True,
+        )
+        
+        return embeddings  # [B, 20, H, W]
+

--- a/metnet/layers/TopographicalEmbedding.py
+++ b/metnet/layers/TopographicalEmbedding.py
@@ -4,32 +4,32 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+
 class TopographicalEmbedding(nn.Module):
     """
     Topographical Embedding class
 
-    "we allocate a grid of embeddings with a stride of 4 km where each point is associated with 20 scalar parameters." 
+    "we allocate a grid of embeddings with a stride of 4 km where each point is associated with 20 scalar parameters."
 
     """
+
     def __init__(
         self,
         grid_height: int,  # number of 4km grid points in y direction
-        grid_width: int,   # number of 4km grid points in x direction
+        grid_width: int,  # number of 4km grid points in x direction
         embedding_dim: int = 20,
     ):
         super().__init__()
         # Learnable parameter grid — trained like NLP embeddings
-        self.embedding_grid = nn.Parameter(
-            torch.randn(1, embedding_dim, grid_height, grid_width)
-        )
+        self.embedding_grid = nn.Parameter(torch.randn(1, embedding_dim, grid_height, grid_width))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         # x is [B, C, H, W] — we just need batch size and spatial dims
         B, _, H, W = x.shape
-        
+
         # Expand grid to batch size
         grid = self.embedding_grid.expand(B, -1, -1, -1)
-        
+
         # Bilinear interpolation to input spatial size
         # This handles the case where input spatial size differs from grid size
         embeddings = F.interpolate(
@@ -38,6 +38,5 @@ class TopographicalEmbedding(nn.Module):
             mode="bilinear",
             align_corners=True,
         )
-        
-        return embeddings  # [B, 20, H, W]
 
+        return embeddings  # [B, 20, H, W]

--- a/metnet/layers/TopographicalEmbedding.py
+++ b/metnet/layers/TopographicalEmbedding.py
@@ -6,11 +6,10 @@ import torch.nn.functional as F
 
 
 class TopographicalEmbedding(nn.Module):
-    """
-    Topographical Embedding class
+    """ Topographical Embedding class.
 
-    "we allocate a grid of embeddings with a stride of 4 km where each point is associated with 20 scalar parameters."
-
+    From MetNet-3 paper: 'we allocate a grid of embeddings with a stride of 4 km
+    where each point is associated with 20 scalar parameters.'
     """
 
     def __init__(
@@ -19,11 +18,27 @@ class TopographicalEmbedding(nn.Module):
         grid_width: int,  # number of 4km grid points in x direction
         embedding_dim: int = 20,
     ):
+        """Initialize TopographicalEmbedding.
+    
+        Args:
+            grid_height: Number of 4km grid points in y direction
+            grid_width: Number of 4km grid points in x direction
+            embedding_dim: Number of learned parameters per grid point, default 20
+        """
         super().__init__()
         # Learnable parameter grid — trained like NLP embeddings
         self.embedding_grid = nn.Parameter(torch.randn(1, embedding_dim, grid_height, grid_width))
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Compute topographical embeddings for the input tensor.
+    
+        Args:
+            x: Input tensor [Batch, Channels, Height, Width]
+
+        Returns:
+            Topographical embedding tensor [Batch, embedding_dim, Height, Width]
+        """
+
         # x is [B, C, H, W] — we just need batch size and spatial dims
         B, _, H, W = x.shape
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -11,19 +11,20 @@ from metnet.layers.TopographicalEmbedding import TopographicalEmbedding
 
 import torch
 
+
 def test_topographical_embedding_gradients():
     batch, channels, height, width = 2, 12, 624, 624
     x = torch.rand(batch, channels, height, width)
-    
+
     embedding = TopographicalEmbedding(grid_height=624, grid_width=624)
     output = embedding(x)
-    
+
     loss = output.sum()
     loss.backward()
 
-    #Check output shapes
+    # Check output shapes
     assert output.shape == (batch, 20, height, width)
-    
+
     # embedding_grid is a learned parameter so should have gradients
     for name, param in embedding.named_parameters():
         assert param.grad is not None, f"No gradient for {name}"
@@ -33,16 +34,16 @@ def test_topographical_embedding_gradients():
 def test_input_embedding_gradients():
     batch, in_channels, height, width = 2, 793, 16, 16
     x = torch.rand(batch, in_channels, height, width)
-    
+
     embedding = InputEmbedding(in_channels=793)
     output = embedding(x)
-    
+
     loss = output.sum()
     loss.backward()
 
-    #Check output shapes
+    # Check output shapes
     assert output.shape == (batch, 512, height, width)
-    
+
     for name, param in embedding.named_parameters():
         assert param.grad is not None, f"No gradient for {name}"
         assert torch.isfinite(param.grad).all(), f"Non-finite gradient in {name}"

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -1,3 +1,4 @@
+from metnet.layers.InputEmbedding import InputEmbedding
 from metnet.layers.MaxViT import MaxViTBlock, MaxViTDataClass, MetNetMaxVit
 from metnet.layers.StochasticDepth import StochasticDepth
 from metnet.layers.SqueezeExcitation import SqueezeExcite
@@ -6,8 +7,45 @@ from metnet.layers.MultiheadSelfAttention2D import MultiheadSelfAttention2D
 from metnet.layers.PartitionAttention import BlockAttention, GridAttention
 from metnet.layers.ConditionWithTimeMetNet3 import ConditionWithTimeMetNet3
 from metnet.layers.LeadTimeConditioner import LeadTimeConditioner
+from metnet.layers.TopographicalEmbedding import TopographicalEmbedding
 
 import torch
+
+def test_topographical_embedding_gradients():
+    batch, channels, height, width = 2, 12, 624, 624
+    x = torch.rand(batch, channels, height, width)
+    
+    embedding = TopographicalEmbedding(grid_height=624, grid_width=624)
+    output = embedding(x)
+    
+    loss = output.sum()
+    loss.backward()
+
+    #Check output shapes
+    assert output.shape == (batch, 20, height, width)
+    
+    # embedding_grid is a learned parameter so should have gradients
+    for name, param in embedding.named_parameters():
+        assert param.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(param.grad).all(), f"Non-finite gradient in {name}"
+
+
+def test_input_embedding_gradients():
+    batch, in_channels, height, width = 2, 793, 16, 16
+    x = torch.rand(batch, in_channels, height, width)
+    
+    embedding = InputEmbedding(in_channels=793)
+    output = embedding(x)
+    
+    loss = output.sum()
+    loss.backward()
+
+    #Check output shapes
+    assert output.shape == (batch, 512, height, width)
+    
+    for name, param in embedding.named_parameters():
+        assert param.grad is not None, f"No gradient for {name}"
+        assert torch.isfinite(param.grad).all(), f"Non-finite gradient in {name}"
 
 
 def test_condition_with_time_metnet3():


### PR DESCRIPTION
# Pull Request

## Description
This PR attempts to address the step of "Embedding for Sparse + Dense layers" in #55.

Specifically, we add the classes `TopographicalEmbedding` and `InputEmbedding`.

**TopographicalEmbedding** :  Implements the technique described in Section 4.2.1 of the MetNet-3 paper.

**InputEmbedding:** Implements the linear projection described in the "Inputs" section of Part B, in the Supplementary Material part of the MetNet-3 paper: "Inputs are embedded to the internal representation of size 512 using a linear layer." Since inputs are spatial grids, this is implemented as a 1×1 convolution which applies the same linear projection independently at every spatial location. It is used twice in the model — once for the 4km high-resolution path (in_channels=793) and once for the 8km low-resolution path (in_channels=17).

**Note on omissions:** The "Inputs" section also describes two preprocessing steps and a concatenation step that are not included in this PR:

MRMS precipitation rate transformation: tanh(log(r + 1)/4)
Mean/std normalization for all other input channels
Concatenation of all 4km inputs across the channel dimension to produce the 793-channel input tensor

Perhaps we can include these in a future MetNet3Preprocessor class, similar to the existing MetNetPreprocessor used in MetNet-2. The concatenation will be handled in metnet3.py when the full model is wired together. They have been omitted here to keep the scope of this PR focused on the embedding layers themselves.

## How Has This Been Tested?
I added the tests `test_topographical_embedding_gradients` and `test_input_embedding_gradients` to tests/test_layers.py. These tests check output shapes and verify that the gradients are flowing. I tested this locally using the bash command:
`uv run pytest tests/test_layers.py::test_input_embedding_gradients tests/test_layers.py::test_topographical_embedding_gradients -v`

<img width="827" height="179" alt="image" src="https://github.com/user-attachments/assets/c6077b3e-8ac5-4c77-b317-a83e4d2dabf9" />


- [ X] Yes

 ## Checklist:
- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
